### PR TITLE
fix: Fix white text visibility on trace details page

### DIFF
--- a/ui/src/components/TraceDetails.tsx
+++ b/ui/src/components/TraceDetails.tsx
@@ -265,7 +265,7 @@ const TraceDurationBars = ({ spans, onSpanClick, selectedSpanId }: { spans: Trac
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              color: 'white',
+              color: '#000',
               fontSize: 12,
               whiteSpace: 'nowrap',
             }}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -4,8 +4,8 @@
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #213547;
+  background-color: #ffffff;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
- Change default text color from white to dark (#213547) in :root CSS
- Update duration bar text color from white to black in TraceDetails component
- Ensures text is visible on light background (#f5f5f5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)