### PR TITLE
feat: SQL search mode and explorer improvements

### DIFF
--- a/api/controller.go
+++ b/api/controller.go
@@ -197,8 +197,9 @@ func (c *TelemetryController) searchTraces(w http.ResponseWriter, r *http.Reques
 		timeRange := r.URL.Query().Get("timeRange")
 		dateRange = GetDateRangeFromQuery(timeRange)
 	}
+	sqlFilter := r.URL.Query().Get("sql_filter")
 	traceOrSpan := r.URL.Query().Get("traceOrSpan")
-	results, err := c.service.SearchTraces(r.Context(), dateRange, query, page, pageSize, sort, traceOrSpan)
+	results, err := c.service.SearchTraces(r.Context(), dateRange, query, sqlFilter, page, pageSize, sort, traceOrSpan)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to search traces: %v", err), http.StatusInternalServerError)
 		return
@@ -361,8 +362,9 @@ func (c *TelemetryController) getSearchMetrics(w http.ResponseWriter, r *http.Re
 		dateRange = GetDateRangeFromQuery(timeRange)
 	}
 
+	sqlFilter := r.URL.Query().Get("sql_filter")
 	traceOrSpan := r.URL.Query().Get("traceOrSpan")
-	metrics, err := c.service.GetSearchMetrics(r.Context(), dateRange, query, percentile, traceOrSpan)
+	metrics, err := c.service.GetSearchMetrics(r.Context(), dateRange, query, sqlFilter, percentile, traceOrSpan)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to get search metrics: %v", err), http.StatusInternalServerError)
 		return

--- a/api/service.go
+++ b/api/service.go
@@ -755,7 +755,7 @@ func parseAttributeQuery(query string) []AttributeQuery {
 	return nil
 }
 
-func (s *TelemetryService) SearchTraces(ctx context.Context, dateRange DateRange, query string, page, pageSize int, sort SortOption, traceOrSpan string) (*SearchResponse, error) {
+func (s *TelemetryService) SearchTraces(ctx context.Context, dateRange DateRange, query, sqlFilter string, page, pageSize int, sort SortOption, traceOrSpan string) (*SearchResponse, error) {
 	totalStart := time.Now()
 	defer func() {
 		fmt.Printf("[SearchTraces] Total function time: %v\n", time.Since(totalStart))
@@ -766,12 +766,17 @@ func (s *TelemetryService) SearchTraces(ctx context.Context, dateRange DateRange
 
 	base := s.DB.From(goqu.T("denormalized_span"))
 
-	conds := []goqu.Expression{
-		goqu.I("start_time_unix_nano").Gte(startNano),
-		goqu.I("end_time_unix_nano").Lte(endNano),
+	var conds []goqu.Expression
+	if sqlFilter != "" {
+		conds = append(conds, goqu.L(sqlFilter))
+	} else {
+		conds = append(conds,
+			goqu.I("start_time_unix_nano").Gte(startNano),
+			goqu.I("end_time_unix_nano").Lte(endNano),
+		)
 	}
 
-	if query != "" {
+	if sqlFilter == "" && query != "" {
 		if attrs := parseAttributeQuery(query); attrs != nil {
 			var attrConds []goqu.Expression
 			for _, attr := range attrs {
@@ -1430,18 +1435,23 @@ func (s *TelemetryService) getCombinedMetricsForQuery(
 	}, nil
 }
 
-func (s *TelemetryService) GetSearchMetrics(ctx context.Context, dateRange DateRange, query string, percentile int, traceOrSpan string) (*CombinedMetricsResult, error) {
+func (s *TelemetryService) GetSearchMetrics(ctx context.Context, dateRange DateRange, query, sqlFilter string, percentile int, traceOrSpan string) (*CombinedMetricsResult, error) {
 	startNano := dateRange.Start.UnixNano()
 	endNano := dateRange.End.UnixNano()
 
 	base := s.DB.From(goqu.T("denormalized_span"))
 
-	conds := []goqu.Expression{
-		goqu.I("start_time_unix_nano").Gte(startNano),
-		goqu.I("end_time_unix_nano").Lte(endNano),
+	var conds []goqu.Expression
+	if sqlFilter != "" {
+		conds = append(conds, goqu.L(sqlFilter))
+	} else {
+		conds = append(conds,
+			goqu.I("start_time_unix_nano").Gte(startNano),
+			goqu.I("end_time_unix_nano").Lte(endNano),
+		)
 	}
 
-	if query != "" {
+	if sqlFilter == "" && query != "" {
 		if attrs := parseAttributeQuery(query); attrs != nil {
 			var attrConds []goqu.Expression
 			for _, attr := range attrs {

--- a/ui/src/components/SQLPage.tsx
+++ b/ui/src/components/SQLPage.tsx
@@ -1,18 +1,73 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import {
   Box, Button, Typography, Paper, Table, TableBody, TableCell,
   TableContainer, TableHead, TableRow, CircularProgress, Alert,
-  TextField,
+  TextField, Accordion, AccordionSummary, AccordionDetails, Chip,
+  ToggleButtonGroup, ToggleButton, Drawer, IconButton, Collapse,
 } from '@mui/material';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import CloseIcon from '@mui/icons-material/Close';
+import OpenInNewIcon from '@mui/icons-material/OpenInNew';
+import { TraceDetails } from './TraceDetails';
 import { config } from '../config';
 
+interface ColumnInfo {
+  table_name: string;
+  column_name: string;
+  data_type: string;
+}
+
+const DEFAULT_QUERY = `SELECT * REPLACE (
+  resource_attributes::VARCHAR AS resource_attributes,
+  span_attributes::VARCHAR AS span_attributes,
+  events_attributes::VARCHAR AS events_attributes
+) FROM denormalized_span LIMIT 10`;
+
 export function SQLPage() {
-  const [sql, setSql] = useState('SELECT * FROM denormalized_span LIMIT 10');
+  const [sql, setSql] = useState(DEFAULT_QUERY);
   const [rows, setRows] = useState<Record<string, unknown>[] | null>(null);
   const [columns, setColumns] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
+  const [schema, setSchema] = useState<Record<string, ColumnInfo[]>>({});
+  const [schemaView, setSchemaView] = useState<'ddl' | 'columns'>('ddl');
+  const [selectedTraceId, setSelectedTraceId] = useState<string | null>(null);
+  const [selectedSpanId, setSelectedSpanId] = useState<string | null>(null);
+
+  const handleIdClick = (col: string, value: string, row: Record<string, unknown>) => {
+    if (col === 'trace_id') {
+      setSelectedTraceId(value);
+      setSelectedSpanId(null);
+    } else {
+      const traceId = String(row['trace_id'] ?? '');
+      setSelectedTraceId(traceId || value);
+      setSelectedSpanId(value);
+    }
+  };
+
+  useEffect(() => {
+    const fetchSchema = async () => {
+      try {
+        const q = `SELECT table_name, column_name, data_type FROM information_schema.columns WHERE table_schema = 'main' ORDER BY table_name, ordinal_position`;
+        const res = await fetch(`${config.backendUrl}/debug/query?sql=${encodeURIComponent(q)}`);
+        if (!res.ok) return;
+        const data: ColumnInfo[] = await res.json();
+        const grouped: Record<string, ColumnInfo[]> = {};
+        for (const row of data) {
+          if (!grouped[row.table_name]) grouped[row.table_name] = [];
+          grouped[row.table_name].push(row);
+        }
+        setSchema(grouped);
+      } catch {
+        // schema panel is best-effort
+      }
+    };
+    fetchSchema();
+  }, []);
 
   const runQuery = useCallback(async () => {
     const query = sql.trim();
@@ -35,6 +90,7 @@ export function SQLPage() {
       const data: Record<string, unknown>[] = JSON.parse(text) ?? [];
       setRows(data);
       setColumns(data.length > 0 ? Object.keys(data[0]) : []);
+      setExpandedRows(new Set());
     } catch (e) {
       setError(String(e));
     } finally {
@@ -49,11 +105,84 @@ export function SQLPage() {
     }
   };
 
+  const tableOrder = ['denormalized_span', 'metric_data_point', 'log_record', 'cron_jobs'];
+  const tableNames = Object.keys(schema).sort((a, b) => {
+    const ai = tableOrder.indexOf(a);
+    const bi = tableOrder.indexOf(b);
+    if (ai === -1 && bi === -1) return a.localeCompare(b);
+    if (ai === -1) return 1;
+    if (bi === -1) return -1;
+    return ai - bi;
+  });
+
   return (
     <Box>
       <Typography variant="h5" fontWeight={600} mb={3}>
         SQL Explorer
       </Typography>
+
+      {tableNames.length > 0 && (
+        <Accordion disableGutters sx={{ mb: 2 }}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <Typography variant="body2" fontWeight={600}>Database Schema</Typography>
+          </AccordionSummary>
+          <AccordionDetails sx={{ pt: 1 }}>
+            <ToggleButtonGroup
+              value={schemaView}
+              exclusive
+              onChange={(_, v) => { if (v) setSchemaView(v); }}
+              size="small"
+              sx={{ mb: 2 }}
+            >
+              <ToggleButton value="ddl">CREATE TABLE</ToggleButton>
+              <ToggleButton value="columns">Columns</ToggleButton>
+            </ToggleButtonGroup>
+
+            {schemaView === 'ddl' ? (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                {tableNames.map(table => (
+                  <Accordion key={table} disableGutters defaultExpanded={table === 'denormalized_span'} sx={{ '&:before': { display: 'none' }, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+                    <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 36, '& .MuiAccordionSummary-content': { my: 0.5 } }}>
+                      <Typography variant="body2" sx={{ fontFamily: 'monospace', fontWeight: 600 }}>{table}</Typography>
+                    </AccordionSummary>
+                    <AccordionDetails sx={{ pt: 0 }}>
+                      <Box
+                        component="pre"
+                        sx={{ m: 0, p: 1.5, bgcolor: 'action.hover', borderRadius: 1, fontFamily: 'monospace', fontSize: 12, overflowX: 'auto', whiteSpace: 'pre' }}
+                      >
+                        {`CREATE TABLE ${table} (\n${schema[table].map((col, i, arr) => `  ${col.column_name} ${col.data_type}${i < arr.length - 1 ? ',' : ''}`).join('\n')}\n);`}
+                      </Box>
+                    </AccordionDetails>
+                  </Accordion>
+                ))}
+              </Box>
+            ) : (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                {tableNames.map(table => (
+                  <Accordion key={table} disableGutters defaultExpanded={table === 'denormalized_span'} sx={{ '&:before': { display: 'none' }, border: '1px solid', borderColor: 'divider', borderRadius: 1 }}>
+                    <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ minHeight: 36, '& .MuiAccordionSummary-content': { my: 0.5 } }}>
+                      <Typography variant="body2" sx={{ fontFamily: 'monospace', fontWeight: 600 }}>{table}</Typography>
+                    </AccordionSummary>
+                    <AccordionDetails sx={{ pt: 0 }}>
+                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
+                        {schema[table].map(col => (
+                          <Chip
+                            key={col.column_name}
+                            label={`${col.column_name}: ${col.data_type}`}
+                            size="small"
+                            variant="outlined"
+                            sx={{ fontFamily: 'monospace', fontSize: 11 }}
+                          />
+                        ))}
+                      </Box>
+                    </AccordionDetails>
+                  </Accordion>
+                ))}
+              </Box>
+            )}
+          </AccordionDetails>
+        </Accordion>
+      )}
 
       <Paper sx={{ p: 2, mb: 2 }}>
         <TextField
@@ -64,7 +193,7 @@ export function SQLPage() {
           value={sql}
           onChange={e => setSql(e.target.value)}
           onKeyDown={handleKeyDown}
-          placeholder="SELECT * FROM denormalized_span LIMIT 10"
+          placeholder={DEFAULT_QUERY}
           slotProps={{
             input: {
               sx: {
@@ -90,6 +219,16 @@ export function SQLPage() {
         </Box>
       </Paper>
 
+      <Alert severity="info" sx={{ mb: 2 }}>
+        <Typography variant="body2" fontWeight={600} gutterBottom>
+          Querying MAP(VARCHAR, VARIANT) columns
+        </Typography>
+        <Typography variant="body2">
+          Columns like <code>resource_attributes</code>, <code>span_attributes</code>, and <code>events_attributes</code> are stored as <code>MAP(VARCHAR, VARIANT)</code>.
+          The Go driver cannot scan VARIANT values directly — use <code>SELECT * REPLACE (...::VARCHAR AS ...)</code> to cast them to strings, as shown in the default query.
+        </Typography>
+      </Alert>
+
       {error && (
         <Alert severity="error" sx={{ mb: 2, fontFamily: 'monospace', whiteSpace: 'pre-wrap' }}>
           {error}
@@ -108,40 +247,128 @@ export function SQLPage() {
               <Table stickyHeader size="small">
                 <TableHead>
                   <TableRow>
+                    <TableCell padding="none" sx={{ width: 32 }} />
                     {columns.map(col => (
                       <TableCell key={col}>{col}</TableCell>
                     ))}
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {rows.map((row, i) => (
-                    <TableRow key={i} hover>
-                      {columns.map(col => (
-                        <TableCell
-                          key={col}
-                          sx={{
-                            maxWidth: 400,
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                            whiteSpace: 'nowrap',
-                            fontFamily: 'monospace',
-                            fontSize: '0.8125rem',
-                          }}
-                          title={String(row[col] ?? '')}
-                        >
-                          {row[col] === null || row[col] === undefined
-                            ? <Typography component="span" variant="inherit" color="text.disabled">NULL</Typography>
-                            : String(row[col])}
-                        </TableCell>
-                      ))}
-                    </TableRow>
-                  ))}
+                  {rows.map((row, i) => {
+                    const expanded = expandedRows.has(i);
+                    const toggle = () => setExpandedRows(prev => {
+                      const next = new Set(prev);
+                      next.has(i) ? next.delete(i) : next.add(i);
+                      return next;
+                    });
+                    return (
+                      <React.Fragment key={i}>
+                        <TableRow hover onClick={toggle} sx={{ cursor: 'pointer' }}>
+                          <TableCell padding="none" sx={{ width: 32, pl: 0.5 }}>
+                            <IconButton size="small">
+                              {expanded ? <KeyboardArrowDownIcon fontSize="small" /> : <KeyboardArrowRightIcon fontSize="small" />}
+                            </IconButton>
+                          </TableCell>
+                          {columns.map(col => {
+                            const isIdCol = col === 'span_id' || col === 'parent_span_id' || col === 'trace_id';
+                            const val = row[col];
+                            const strVal = val === null || val === undefined ? null : String(val);
+                            return (
+                              <TableCell
+                                key={col}
+                                sx={{
+                                  maxWidth: 300,
+                                  overflow: 'hidden',
+                                  textOverflow: 'ellipsis',
+                                  whiteSpace: 'nowrap',
+                                  fontFamily: 'monospace',
+                                  fontSize: '0.8125rem',
+                                }}
+                              >
+                                {strVal === null
+                                  ? <Typography component="span" variant="inherit" color="text.disabled">NULL</Typography>
+                                  : isIdCol && strVal
+                                    ? (
+                                      <Box
+                                        component="span"
+                                        onClick={e => { e.stopPropagation(); handleIdClick(col, strVal, row); }}
+                                        sx={{ cursor: 'pointer', textDecoration: 'underline dotted', textDecorationColor: 'primary.main', color: 'primary.main' }}
+                                      >
+                                        {strVal}
+                                      </Box>
+                                    )
+                                    : strVal}
+                              </TableCell>
+                            );
+                          })}
+                        </TableRow>
+                        {expanded && (
+                          <TableRow>
+                            <TableCell colSpan={columns.length + 1} sx={{ py: 0, bgcolor: 'action.hover' }}>
+                              <Collapse in={expanded} unmountOnExit>
+                                <Box sx={{ p: 1.5, display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                                  {columns.map(col => {
+                                    const val = row[col];
+                                    const strVal = val === null || val === undefined ? null : String(val);
+                                    return (
+                                      <Box key={col} sx={{ display: 'flex', gap: 1, fontFamily: 'monospace', fontSize: 12 }}>
+                                        <Typography component="span" sx={{ fontFamily: 'monospace', fontSize: 12, fontWeight: 700, flexShrink: 0, color: 'text.secondary' }}>
+                                          {col}:
+                                        </Typography>
+                                        <Typography component="span" sx={{ fontFamily: 'monospace', fontSize: 12, wordBreak: 'break-all', whiteSpace: 'pre-wrap' }}>
+                                          {strVal === null ? <span style={{ opacity: 0.4 }}>NULL</span> : strVal}
+                                        </Typography>
+                                      </Box>
+                                    );
+                                  })}
+                                </Box>
+                              </Collapse>
+                            </TableCell>
+                          </TableRow>
+                        )}
+                      </React.Fragment>
+                    );
+                  })}
                 </TableBody>
               </Table>
             </TableContainer>
           )}
         </>
       )}
+      <Drawer
+        anchor="right"
+        open={selectedTraceId !== null}
+        onClose={() => { setSelectedTraceId(null); setSelectedSpanId(null); }}
+        PaperProps={{ sx: { width: '80vw', display: 'flex', flexDirection: 'column' } }}
+      >
+        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', px: 2, py: 1, borderBottom: 1, borderColor: 'divider', flexShrink: 0 }}>
+          <Typography variant="subtitle1" sx={{ fontFamily: 'monospace', fontSize: '0.85rem', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {selectedTraceId}
+          </Typography>
+          <Box sx={{ display: 'flex', gap: 1, flexShrink: 0 }}>
+            <Button
+              size="small"
+              startIcon={<OpenInNewIcon />}
+              onClick={() => window.open(`/traces/${encodeURIComponent(selectedTraceId ?? '')}`, '_blank')}
+            >
+              Open in new tab
+            </Button>
+            <IconButton size="small" onClick={() => { setSelectedTraceId(null); setSelectedSpanId(null); }}>
+              <CloseIcon />
+            </IconButton>
+          </Box>
+        </Box>
+        <Box sx={{ flex: 1, overflow: 'auto', p: 2 }}>
+          {selectedTraceId && (
+            <TraceDetails
+              traceId={selectedTraceId}
+              initialSpanId={selectedSpanId ?? undefined}
+              onAddToSearch={() => {}}
+              onAddAsColumn={() => {}}
+            />
+          )}
+        </Box>
+      </Drawer>
     </Box>
   );
 }

--- a/ui/src/components/TracesPage.tsx
+++ b/ui/src/components/TracesPage.tsx
@@ -133,6 +133,8 @@ export const TracesPage: React.FC = () => {
   const [traceOrSpan, setTraceOrSpan] = useState<"trace" | "span" | "all">("trace");
 
   const [query, setQuery] = useState('');
+  const [sqlMode, setSqlMode] = useState(false);
+  const [sqlFilter, setSqlFilter] = useState('');
   const [searchResponse, setSearchResponse] = useState<SearchResponse | null>(null);
   const [traceCountSeries, setTraceCountSeries] = useState<TimePercentile[]>([]);
   const [loading, setLoading] = useState(false);
@@ -283,32 +285,40 @@ export const TracesPage: React.FC = () => {
     preset = timePreset,
     silent = false,
     skipUrlPush = false,
+    sqlFilterValue = sqlFilter,
+    isSqlMode = sqlMode,
   ) => {
     const resolvedStart = preset !== 'custom' ? getPresetDates(preset).start : start;
     const resolvedEnd   = preset !== 'custom' ? getPresetDates(preset).end   : end;
 
-    if (!resolvedStart || !resolvedEnd || isNaN(resolvedStart.getTime()) || isNaN(resolvedEnd.getTime())) {
+    if (!isSqlMode && (!resolvedStart || !resolvedEnd || isNaN(resolvedStart.getTime()) || isNaN(resolvedEnd.getTime()))) {
       setError('Invalid start or end date');
       return;
     }
 
     let effectiveQuery = q;
-    const alreadyInQuery = q.split(',').some(p => p.trim().startsWith('service.name='));
-    if (service && !alreadyInQuery) {
-      const serviceFilter = `service.name=${service}`;
-      effectiveQuery = q ? `${serviceFilter},${q}` : serviceFilter;
+    if (!isSqlMode) {
+      const alreadyInQuery = q.split(',').some(p => p.trim().startsWith('service.name='));
+      if (service && !alreadyInQuery) {
+        const serviceFilter = `service.name=${service}`;
+        effectiveQuery = q ? `${serviceFilter},${q}` : serviceFilter;
+      }
     }
 
     const params: Record<string, string> = {
-      query: effectiveQuery,
       page: String(pageNum),
       pageSize: String(size),
       sortField: sf,
       sortOrder: so,
-      start: resolvedStart.toISOString(),
-      end: resolvedEnd.toISOString(),
-      traceOrSpan: traceOrSpanValue,
     };
+    if (isSqlMode) {
+      params.sql_filter = sqlFilterValue;
+    } else {
+      params.query = effectiveQuery;
+      params.start = resolvedStart!.toISOString();
+      params.end = resolvedEnd!.toISOString();
+      params.traceOrSpan = traceOrSpanValue;
+    }
 
     const urlParams: Record<string, string> = {
       query: effectiveQuery,
@@ -346,19 +356,21 @@ export const TracesPage: React.FC = () => {
       setSearchResponse(searchData);
       setPage(pageNum);
 
-      const metricsUrl = new URL(`${config.backendUrl}/api/metrics/search`);
-      metricsUrl.searchParams.set('query', effectiveQuery);
-      metricsUrl.searchParams.set('start', resolvedStart.toISOString());
-      metricsUrl.searchParams.set('end', resolvedEnd.toISOString());
-      metricsUrl.searchParams.set('traceOrSpan', traceOrSpanValue);
+      if (!isSqlMode) {
+        const metricsUrl = new URL(`${config.backendUrl}/api/metrics/search`);
+        metricsUrl.searchParams.set('query', effectiveQuery);
+        metricsUrl.searchParams.set('start', resolvedStart!.toISOString());
+        metricsUrl.searchParams.set('end', resolvedEnd!.toISOString());
+        metricsUrl.searchParams.set('traceOrSpan', traceOrSpanValue);
 
-      const metricsResponse = await fetch(metricsUrl.toString());
-      if (metricsResponse.ok) {
-        const metricsData = await metricsResponse.json();
-        setTraceCountSeries(metricsData.TraceCountResults || []);
-      } else {
-        console.error('Failed to fetch metrics:', await metricsResponse.text());
-        setTraceCountSeries([]);
+        const metricsResponse = await fetch(metricsUrl.toString());
+        if (metricsResponse.ok) {
+          const metricsData = await metricsResponse.json();
+          setTraceCountSeries(metricsData.TraceCountResults || []);
+        } else {
+          console.error('Failed to fetch metrics:', await metricsResponse.text());
+          setTraceCountSeries([]);
+        }
       }
     } catch (err) {
       if (!silent) {
@@ -379,7 +391,7 @@ export const TracesPage: React.FC = () => {
   const silentRefreshRef = useRef(() => {});
   useEffect(() => {
     silentRefreshRef.current = () =>
-      handleSearch(page, query, pageSize, sortField, sortOrder, startDate, endDate, selectedService, traceOrSpan, timePreset, true);
+      handleSearch(page, query, pageSize, sortField, sortOrder, startDate, endDate, selectedService, traceOrSpan, timePreset, true, false, sqlFilter, sqlMode);
   });
 
   useEffect(() => {
@@ -479,7 +491,7 @@ export const TracesPage: React.FC = () => {
       <Box sx={{ gridColumn: 'span 12', display: 'flex', flexDirection: 'column', gap: 1.5 }}>
       <Box sx={{ display: 'flex', gap: 2, flexWrap: 'wrap', alignItems: 'center' }}>
 
-        <FormControl size="small" sx={{ minWidth: 150 }}>
+        <FormControl size="small" sx={{ minWidth: 150 }} disabled={sqlMode}>
           <InputLabel>Time Range</InputLabel>
           <Select value={timePreset} label="Time Range" onChange={handlePresetChange}>
             <MenuItem value="5m">Last 5 minutes</MenuItem>
@@ -493,7 +505,7 @@ export const TracesPage: React.FC = () => {
           </Select>
         </FormControl>
 
-        {timePreset === 'custom_min' && (
+        {!sqlMode && timePreset === 'custom_min' && (
           <TextField
             label="Minutes"
             type="number"
@@ -508,7 +520,7 @@ export const TracesPage: React.FC = () => {
           />
         )}
 
-        {timePreset === 'custom' && (
+        {!sqlMode && timePreset === 'custom' && (
           <>
             <TextField
               label="Start Time"
@@ -569,7 +581,7 @@ export const TracesPage: React.FC = () => {
           </>
         )}
 
-        <FormControl size="small" sx={{ minWidth: 200 }}>
+        <FormControl size="small" sx={{ minWidth: 200 }} disabled={sqlMode}>
           <InputLabel shrink>Service</InputLabel>
           <Select value={selectedService} label="Service" onChange={handleServiceChange} displayEmpty renderValue={v => v || 'All Services'} notched>
             <MenuItem value="">All Services</MenuItem>
@@ -579,7 +591,7 @@ export const TracesPage: React.FC = () => {
           </Select>
         </FormControl>
 
-        <FormControl size="small" sx={{ minWidth: 200 }}>
+        <FormControl size="small" sx={{ minWidth: 200 }} disabled={sqlMode}>
           <InputLabel>Trace Or Span</InputLabel>
           <Select value={traceOrSpan} label="Trace Or Span" onChange={handleTraceOrSpanChange}>
             <MenuItem value="all">All</MenuItem>
@@ -588,10 +600,35 @@ export const TracesPage: React.FC = () => {
           </Select>
         </FormControl>
 
+        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+          <Typography variant="body2">SQL</Typography>
+          <Switch
+            checked={sqlMode}
+            onChange={e => setSqlMode(e.target.checked)}
+            size="small"
+          />
+        </Box>
+
       </Box>
       <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
-        <FilterChipInput value={query} onChange={setQuery} onSearch={(q) => handleSearch(1, q)} />
-        <Button variant="outlined" startIcon={<RefreshIcon />} onClick={() => handleSearch(1)} disabled={loading}>
+        {sqlMode ? (
+          <TextField
+            multiline
+            minRows={2}
+            maxRows={6}
+            size="small"
+            fullWidth
+            placeholder="span_attributes['http.method']::VARCHAR = 'GET' AND duration_ns > 1000000"
+            value={sqlFilter}
+            onChange={e => setSqlFilter(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleSearch(1, query, pageSize, sortField, sortOrder, startDate, endDate, selectedService, traceOrSpan, timePreset, false, false, sqlFilter, true); }}
+            sx={{ fontFamily: 'monospace' }}
+            inputProps={{ style: { fontFamily: 'monospace', fontSize: 13 } }}
+          />
+        ) : (
+          <FilterChipInput value={query} onChange={setQuery} onSearch={(q) => handleSearch(1, q)} />
+        )}
+        <Button variant="outlined" startIcon={<RefreshIcon />} onClick={() => handleSearch(1, query, pageSize, sortField, sortOrder, startDate, endDate, selectedService, traceOrSpan, timePreset, false, false, sqlFilter, sqlMode)} disabled={loading}>
           Refresh
         </Button>
       </Box>
@@ -607,7 +644,12 @@ export const TracesPage: React.FC = () => {
           <CircularProgress />
         </Box>
       )}
-      {!loading && searchResponse && (
+      {sqlMode && (
+        <Box sx={{ gridColumn: 'span 12' }}>
+          <Typography variant="body2" color="text.secondary">Charts are not available in SQL mode.</Typography>
+        </Box>
+      )}
+      {!sqlMode && !loading && searchResponse && (
         <Box sx={{ gridColumn: 'span 12' }}>
           <TraceCountChart
             data={traceCountSeries}


### PR DESCRIPTION
  Summary

  - Add SQL mode to the traces search page — toggle disables date/service/span selectors and accepts a raw SQL WHERE clause; charts are hidden in
  this mode
  - SQL explorer: schema panel with CREATE TABLE / columns views (collapsible per table, ordered span → metrics → logs → cron jobs), default query
   uses SELECT * REPLACE to work around MAP(VARCHAR, VARIANT) driver limitation with an explanatory note
  - SQL explorer results: click any row to expand inline and see full cell values; click span_id, parent_span_id, or trace_id to open the trace
  detail drawer

  Test plan

  - Toggle SQL mode on traces page — date/service/span selectors are disabled, chart shows "not available" message
  - Run a SQL WHERE clause in traces SQL mode (e.g. name ILIKE '%users%') and confirm results appear
  - Confirm metrics endpoint is not called in SQL mode (check network tab)
  - Open SQL explorer, expand schema panel, verify CREATE TABLE and Columns views both render correctly
  - Run SELECT * FROM denormalized_span LIMIT 10 — should fail with VARIANT error; run the default query with REPLACE — should succeed
  - Click a result row to expand; verify all column values are shown in full
  - Click a trace_id or span_id value to open the trace drawer

