### PR TITLE
feat: show total count and page number buttons on traces and logs pages

### DIFF
--- a/api/controller.go
+++ b/api/controller.go
@@ -513,7 +513,7 @@ func (c *TelemetryController) getLogs(w http.ResponseWriter, r *http.Request) {
 	page, _ := strconv.Atoi(q.Get("page"))
 	pageSize, _ := strconv.Atoi(q.Get("pageSize"))
 
-	rows, err := c.service.GetLogs(r.Context(), dr,
+	resp, err := c.service.GetLogs(r.Context(), dr,
 		q.Get("trace_id"), q.Get("span_id"), q.Get("service"), q.Get("severity"), q.Get("body"),
 		q.Get("sort"), q.Get("sort_dir"),
 		page, pageSize,
@@ -523,7 +523,7 @@ func (c *TelemetryController) getLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(rows)
+	json.NewEncoder(w).Encode(resp)
 }
 
 func (c *TelemetryController) getLogVolume(w http.ResponseWriter, r *http.Request) {

--- a/api/service.go
+++ b/api/service.go
@@ -124,9 +124,10 @@ type SearchResult struct {
 }
 
 type SearchResponse struct {
-	Results  []SearchResult `json:"results"`
-	Page     int            `json:"page"`
-	PageSize int            `json:"pageSize"`
+	Results    []SearchResult `json:"results"`
+	Page       int            `json:"page"`
+	PageSize   int            `json:"pageSize"`
+	TotalCount uint64         `json:"totalCount"`
 }
 
 type SortOption struct {
@@ -903,6 +904,15 @@ func (s *TelemetryService) SearchTraces(ctx context.Context, dateRange DateRange
 		ds = ds.Order(goqu.I("start_time_unix_nano").Desc())
 	}
 
+	countSQL, countArgs, err := base.Select(goqu.L("COUNT(*)")).Where(conds...).ToSQL()
+	if err != nil {
+		return nil, err
+	}
+	var totalCount uint64
+	if err := s.Ch.QueryRowContext(ctx, countSQL, countArgs...).Scan(&totalCount); err != nil {
+		return nil, err
+	}
+
 	ds = ds.Limit(uint(pageSize)).Offset(uint(offset))
 	sqlStr, args, err := ds.ToSQL()
 	if err != nil {
@@ -952,9 +962,10 @@ func (s *TelemetryService) SearchTraces(ctx context.Context, dateRange DateRange
 	}
 
 	return &SearchResponse{
-		Results:  results,
-		Page:     page,
-		PageSize: pageSize,
+		Results:    results,
+		Page:       page,
+		PageSize:   pageSize,
+		TotalCount: totalCount,
 	}, rows.Err()
 }
 
@@ -1854,7 +1865,12 @@ type LogRow struct {
 	ResourceAttributes map[string]string `json:"resource_attributes"`
 }
 
-func (s *TelemetryService) GetLogs(ctx context.Context, dr DateRange, traceID, spanID, service, severity, body, sortField, sortDir string, page, pageSize int) ([]LogRow, error) {
+type LogsResponse struct {
+	Rows       []LogRow `json:"rows"`
+	TotalCount uint64   `json:"totalCount"`
+}
+
+func (s *TelemetryService) GetLogs(ctx context.Context, dr DateRange, traceID, spanID, service, severity, body, sortField, sortDir string, page, pageSize int) (*LogsResponse, error) {
 	if pageSize <= 0 {
 		pageSize = 50
 	}
@@ -1881,30 +1897,40 @@ func (s *TelemetryService) GetLogs(ctx context.Context, dr DateRange, traceID, s
 	var query string
 	var args []any
 
+	var countQuery string
+	var countArgs []any
+
 	if body != "" {
 		var outerConds []string
 		args = append(args, body)
+		countArgs = append(countArgs, body)
 		if spanID != "" {
 			outerConds = append(outerConds, "span_id = ?")
 			args = append(args, spanID)
+			countArgs = append(countArgs, spanID)
 		} else if traceID != "" {
 			outerConds = append(outerConds, "trace_id = ?")
 			args = append(args, traceID)
+			countArgs = append(countArgs, traceID)
 		} else {
 			outerConds = append(outerConds, "timestamp_unix_nano >= ?", "timestamp_unix_nano <= ?")
 			args = append(args, dr.Start.UnixNano(), dr.End.UnixNano())
+			countArgs = append(countArgs, dr.Start.UnixNano(), dr.End.UnixNano())
 		}
 		if service != "" {
 			outerConds = append(outerConds, "service_name = ?")
 			args = append(args, service)
+			countArgs = append(countArgs, service)
 		}
 		if severity != "" {
 			outerConds = append(outerConds, "severity_text = ?")
 			args = append(args, severity)
+			countArgs = append(countArgs, severity)
 		}
 		outerConds = append(outerConds, "__score IS NOT NULL")
 		args = append(args, pageSize, offset)
 
+		whereClause := strings.Join(outerConds, " AND ")
 		query = fmt.Sprintf(`
 			SELECT
 				timestamp_unix_nano, severity_text, severity_number,
@@ -1918,29 +1944,41 @@ func (s *TelemetryService) GetLogs(ctx context.Context, dr DateRange, traceID, s
 			WHERE %s
 			ORDER BY %s %s
 			LIMIT ? OFFSET ?
-		`, strings.Join(outerConds, " AND "), orderCol, orderDir)
+		`, whereClause, orderCol, orderDir)
+		countQuery = fmt.Sprintf(`
+			SELECT COUNT(*) FROM (
+				SELECT *, fts_main_log_record.match_bm25(rowid, ?) AS __score
+				FROM log_record
+			) WHERE %s
+		`, whereClause)
 	} else {
 		var conds []string
 		if spanID != "" {
 			conds = append(conds, "span_id = ?")
 			args = append(args, spanID)
+			countArgs = append(countArgs, spanID)
 		} else if traceID != "" {
 			conds = append(conds, "trace_id = ?")
 			args = append(args, traceID)
+			countArgs = append(countArgs, traceID)
 		} else {
 			conds = append(conds, "timestamp_unix_nano >= ?", "timestamp_unix_nano <= ?")
 			args = append(args, dr.Start.UnixNano(), dr.End.UnixNano())
+			countArgs = append(countArgs, dr.Start.UnixNano(), dr.End.UnixNano())
 		}
 		if service != "" {
 			conds = append(conds, "service_name = ?")
 			args = append(args, service)
+			countArgs = append(countArgs, service)
 		}
 		if severity != "" {
 			conds = append(conds, "severity_text = ?")
 			args = append(args, severity)
+			countArgs = append(countArgs, severity)
 		}
 		args = append(args, pageSize, offset)
 
+		whereClause := strings.Join(conds, " AND ")
 		query = fmt.Sprintf(`
 			SELECT
 				timestamp_unix_nano, severity_text, severity_number,
@@ -1951,7 +1989,13 @@ func (s *TelemetryService) GetLogs(ctx context.Context, dr DateRange, traceID, s
 			WHERE %s
 			ORDER BY %s %s
 			LIMIT ? OFFSET ?
-		`, strings.Join(conds, " AND "), orderCol, orderDir)
+		`, whereClause, orderCol, orderDir)
+		countQuery = fmt.Sprintf(`SELECT COUNT(*) FROM log_record WHERE %s`, whereClause)
+	}
+
+	var totalCount uint64
+	if err := s.Ch.QueryRowContext(ctx, countQuery, countArgs...).Scan(&totalCount); err != nil {
+		return nil, fmt.Errorf("count query error: %w", err)
 	}
 
 	rows, err := s.Ch.QueryContext(ctx, query, args...)
@@ -1989,7 +2033,7 @@ func (s *TelemetryService) GetLogs(ctx context.Context, dr DateRange, traceID, s
 	if result == nil {
 		result = []LogRow{}
 	}
-	return result, rows.Err()
+	return &LogsResponse{Rows: result, TotalCount: totalCount}, rows.Err()
 }
 
 type LogVolumeBucket struct {

--- a/ui/src/components/LogsPage.tsx
+++ b/ui/src/components/LogsPage.tsx
@@ -3,7 +3,7 @@ import {
   Box, Typography, CircularProgress, Select, MenuItem, FormControl,
   InputLabel, Button, Table, TableBody, TableCell, TableContainer,
   TableHead, TableRow, Paper, Chip, TextField, Switch,
-  TablePagination, TableSortLabel, Collapse, IconButton,
+  TableSortLabel, Collapse, IconButton,
 } from '@mui/material';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
@@ -122,6 +122,7 @@ export const LogsPage: React.FC = () => {
   const [refreshIntervalIdx, setRefreshIntervalIdx] = useState(1);
 
   const [logs, setLogs] = useState<LogRow[]>([]);
+  const [totalCount, setTotalCount] = useState<number>(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [chartData, setChartData] = useState<ChartBucket[]>([]);
@@ -169,8 +170,10 @@ export const LogsPage: React.FC = () => {
       .then(res => res.ok ? res.json() : []);
 
     Promise.all([logsReq, volReq])
-      .then(([data, volData]: [LogRow[], LogVolumeBucket[]]) => {
+      .then(([logsResp, volData]: [{ rows: LogRow[]; totalCount: number }, LogVolumeBucket[]]) => {
+        const data = logsResp.rows ?? [];
         setLogs(data);
+        setTotalCount(logsResp.totalCount ?? 0);
         setExpandedRows(new Set());
 
         const bucketMap = new Map<number, ChartBucket>();
@@ -342,6 +345,11 @@ export const LogsPage: React.FC = () => {
         <Typography color="error">{error}</Typography>
       ) : (
         <>
+          {totalCount > 0 && (
+            <Typography variant="body2" color="text.secondary" mb={1}>
+              {totalCount.toLocaleString()} {totalCount === 1 ? 'result' : 'results'}
+            </Typography>
+          )}
           <TableContainer component={Paper}>
             <Table size="small">
               <TableHead>
@@ -439,16 +447,36 @@ export const LogsPage: React.FC = () => {
               </TableBody>
             </Table>
           </TableContainer>
-          <TablePagination
-            component="div"
-            count={-1}
-            page={page}
-            onPageChange={(_, p) => setPage(p)}
-            rowsPerPage={pageSize}
-            onRowsPerPageChange={e => { setPageSize(parseInt(e.target.value)); setPage(0); }}
-            rowsPerPageOptions={[20, 50, 100]}
-            labelDisplayedRows={({ from, to }) => `${from}–${to}`}
-          />
+          <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mt: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Typography variant="body2" color="text.secondary">Rows per page:</Typography>
+              <Select size="small" value={pageSize} onChange={e => { setPageSize(Number(e.target.value)); setPage(0); }}>
+                {[20, 50, 100].map(n => <MenuItem key={n} value={n}>{n}</MenuItem>)}
+              </Select>
+            </Box>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
+              {(() => {
+                const totalPages = totalCount > 0 ? Math.ceil(totalCount / pageSize) : page + 1;
+                return (
+                  <>
+                    <Button disabled={page === 0} onClick={() => setPage(page - 1)}>Previous</Button>
+                    {Array.from({ length: totalPages }, (_, i) => i + 1)
+                      .filter(p => p === 1 || p === totalPages || Math.abs(p - (page + 1)) <= 2)
+                      .reduce<(number | 'ellipsis')[]>((acc, p, i, arr) => {
+                        if (i > 0 && p - (arr[i - 1] as number) > 1) acc.push('ellipsis');
+                        acc.push(p);
+                        return acc;
+                      }, [])
+                      .map((p, i) => p === 'ellipsis'
+                        ? <Typography key={`e${i}`} sx={{ px: 0.5 }}>…</Typography>
+                        : <Button key={p} variant={p === page + 1 ? 'contained' : 'text'} size="small" onClick={() => setPage((p as number) - 1)} sx={{ minWidth: 36 }}>{p}</Button>
+                      )}
+                    <Button disabled={page + 1 >= totalPages} onClick={() => setPage(page + 1)}>Next</Button>
+                  </>
+                );
+              })()}
+            </Box>
+          </Box>
         </>
       )}
     </Box>

--- a/ui/src/components/TracesPage.tsx
+++ b/ui/src/components/TracesPage.tsx
@@ -55,6 +55,7 @@ interface SearchResponse {
   results?: SearchResult[];
   page: number;
   pageSize: number;
+  totalCount?: number;
 }
 
 const FilterChipInput = ({ value, onChange, onSearch }: { value: string; onChange: (v: string) => void; onSearch: (q: string) => void }) => {
@@ -488,7 +489,8 @@ export const TracesPage: React.FC = () => {
   const formatTimestamp = (ns: number) => format(new Date(ns / 1e6), 'yyyy-MM-dd HH:mm:ss.SSS');
   const formatDuration = (ms: number) => `${ms.toFixed(2)} ms`;
   const hasResults = (searchResponse?.results?.length ?? 0) > 0;
-  const hasMorePages = hasResults && searchResponse!.results!.length >= pageSize;
+  const totalCount = searchResponse?.totalCount ?? 0;
+  const totalPages = totalCount > 0 ? Math.ceil(totalCount / pageSize) : (hasResults && searchResponse!.results!.length >= pageSize ? page + 1 : page);
 
   return (
     <Box sx={{ p: 3, display: 'grid', gridTemplateColumns: 'repeat(12, 1fr)', gap: 2 }}>
@@ -666,7 +668,12 @@ export const TracesPage: React.FC = () => {
       {!loading && (searchResponse?.results?.length ?? 0) > 0 && (
         <>
           <Box sx={{ gridColumn: 'span 12' }}>
-            <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+              {searchResponse?.totalCount !== undefined && (
+                <Typography variant="body2" color="text.secondary">
+                  {searchResponse.totalCount.toLocaleString()} {searchResponse.totalCount === 1 ? 'result' : 'results'}
+                </Typography>
+              )}
               <Button size="small" startIcon={<ViewColumnIcon />} onClick={e => {
                 const r = e.currentTarget.getBoundingClientRect();
                 setColumnAnchorPos({ top: r.bottom, left: r.right });
@@ -779,10 +786,20 @@ export const TracesPage: React.FC = () => {
                 ))}
               </Select>
             </FormControl>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
               <Button disabled={page <= 1} onClick={() => handleSearch(page - 1)}>Previous</Button>
-              <Typography>Page {page}</Typography>
-              <Button disabled={!hasMorePages} onClick={() => handleSearch(page + 1)}>Next</Button>
+              {Array.from({ length: totalPages }, (_, i) => i + 1)
+                .filter(p => p === 1 || p === totalPages || Math.abs(p - page) <= 2)
+                .reduce<(number | 'ellipsis')[]>((acc, p, i, arr) => {
+                  if (i > 0 && p - (arr[i - 1] as number) > 1) acc.push('ellipsis');
+                  acc.push(p);
+                  return acc;
+                }, [])
+                .map((p, i) => p === 'ellipsis'
+                  ? <Typography key={`e${i}`} sx={{ px: 0.5 }}>…</Typography>
+                  : <Button key={p} variant={p === page ? 'contained' : 'text'} size="small" onClick={() => handleSearch(p as number)} sx={{ minWidth: 36 }}>{p}</Button>
+                )}
+              <Button disabled={page >= totalPages} onClick={() => handleSearch(page + 1)}>Next</Button>
             </Box>
           </Box>
         </>


### PR DESCRIPTION
Both pages now return a total count from the backend and display it above the results. Pagination replaced with numbered page buttons (with ellipsis) derived from the total count.